### PR TITLE
APM-398: Update bash start script to support an optional parameter

### DIFF
--- a/start_all_with_inspectIT.sh
+++ b/start_all_with_inspectIT.sh
@@ -1,8 +1,18 @@
 #!/bin/sh
-#usage: ./start_all_with_inspectIT.sh <path to agent inspectIT agent>
+#usage: ./start_all_with_inspectIT.sh <path to inspectIT agent> <CMR host>
 #the startup scipt must be placed in the same folder than the spring petclinic microservice application
 #the path to the inspectit installation folder and the waittime between the startup of the services
 #!!!!do not use spaces in the path of the inspectIT installation folder!!!!
+
+if [ "$#" -le 1 ]; then
+  echo "Please specify the path to the inspectIT agent"
+  exit 1
+fi
+if [ "$#" -ne 2 ]; then
+  CMR_HOST="localhost"
+else
+  CMR_HOST="$2"
+fi
 
 AGENTDIR="$1"
 
@@ -32,35 +42,35 @@ then
 
 	cd spring-petclinic-customers-service
 	echo "Starting Customers Service"
-	mvn spring-boot:run -Drun.jvmArguments="-javaagent:${AGENTDIR}/inspectit-agent.jar -Dinspectit.repository=localhost:9070 -Dinspectit.agent.name=customers-service" &
+	mvn spring-boot:run -Drun.jvmArguments="-javaagent:${AGENTDIR}/inspectit-agent.jar -Dinspectit.repository=${CMR_HOST}:9070 -Dinspectit.agent.name=customers-service" &
 	cd ..
 
 	./wait-for-it.sh localhost:8761 --timeout=60
 
 	cd spring-petclinic-vets-service
 	echo "Starting Vets Service"
-	mvn spring-boot:run -Drun.jvmArguments="-javaagent:${AGENTDIR}/inspectit-agent.jar -Dinspectit.repository=localhost:9070 -Dinspectit.agent.name=vets-service" &
+	mvn spring-boot:run -Drun.jvmArguments="-javaagent:${AGENTDIR}/inspectit-agent.jar -Dinspectit.repository=${CMR_HOST}:9070 -Dinspectit.agent.name=vets-service" &
 	cd ..
 
 	./wait-for-it.sh localhost:8761 --timeout=60
 
 	cd spring-petclinic-visits-service
 	echo "Starting Visits Service"
-	mvn spring-boot:run -Drun.jvmArguments="-javaagent:${AGENTDIR}/inspectit-agent.jar -Dinspectit.repository=localhost:9070 -Dinspectit.agent.name=visits-service" &
+	mvn spring-boot:run -Drun.jvmArguments="-javaagent:${AGENTDIR}/inspectit-agent.jar -Dinspectit.repository=${CMR_HOST}:9070 -Dinspectit.agent.name=visits-service" &
 	cd ..
 
 	./wait-for-it.sh localhost:8761 --timeout=60
 
 	cd spring-petclinic-api-gateway
 	echo "Starting API Gateway"
-	mvn spring-boot:run -Drun.jvmArguments="-javaagent:${AGENTDIR}/inspectit-agent.jar -Dinspectit.repository=localhost:9070 -Dinspectit.agent.name=api-gateway" &
+	mvn spring-boot:run -Drun.jvmArguments="-javaagent:${AGENTDIR}/inspectit-agent.jar -Dinspectit.repository=${CMR_HOST}:9070 -Dinspectit.agent.name=api-gateway" &
 	cd ..
 
 	./wait-for-it.sh localhost:8761 --timeout=60
 
 	cd spring-petclinic-admin-server
 	echo "Starting Admin Server"
-	mvn spring-boot:run -Drun.jvmArguments="-javaagent:${AGENTDIR}/inspectit-agent.jar -Dinspectit.repository=localhost:9070 -Dinspectit.agent.name=admin-server" &
+	mvn spring-boot:run -Drun.jvmArguments="-javaagent:${AGENTDIR}/inspectit-agent.jar -Dinspectit.repository=${CMR_HOST}:9070 -Dinspectit.agent.name=admin-server" &
 	cd ..
 
 	./wait-for-it.sh localhost:8080 --timeout=240
@@ -69,7 +79,9 @@ then
 	echo "All Services started!"
 
 else
-	echo Agent jar not found. Specify the path to the inspectIT agent
-	echo Example: ./start_all_with_inspectIT.sh /home/user/inspectIT/agent
-	echo In case you have not installed inspectIT go to https://github.com/inspectIT/inspectIT/releases
+  echo Agent jar not found. Specify the path to the inspectIT agent
+  echo Example: ./start_all_with_inspectIT.sh /home/user/inspectIT/agent
+  echo Optionally you can also specify the CMR_HOST as second arugment
+  echo Example: ./start_all_with_inspectIT.sh /home/user/inspectIT/agent localhost
+  echo In case you have not installed inspectIT go to https://github.com/inspectIT/inspectIT/releases
 fi


### PR DESCRIPTION
Update bash start script to support an optional parameter to set the CMR_HOST

Add an additional parameter for setting the CMR_HOST for the bash startup script. If no parameter is supplied the CMR_HOST is set to `localhost`. This is especially useful when used with Docker containers and when the CMR server runs in a different network.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit-labs/spring-petclinic-microservices/8)
<!-- Reviewable:end -->
