### PR TITLE
APM-398: Update bat start script to support Jenkins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,17 @@ You can tell Config Server to use your local Git repository by using `local` Spr
 All services including the inspectIT Java Agent can be started with a start script:
 #### Windows
 Open a CMD and execute the script with the directory of the Java Agent:
-`start_all_with_inspectIT.bat \path\to\Java\Agent`. The services can be stopped by closing the CMD.
+`start_all_with_inspectIT.bat \path\to\Java\Agent`.
+Additionally you can also set the InspectIT CMR host by passing in a second argument:
+`start_all_with_inspectIT.bat \path\to\Java\Agent localhost`. If no CMR host is provided `localhost` is used by default.   
+The services can be stopped by closing the CMD.  
+
 #### Linux
 Open a Terminal and execute the script with the directory of the Java Agent:
-`start_all_with_inspectIT.sh \path\to\Java\Agent`. The services can be stopped by executing the following script:
+`start_all_with_inspectIT.sh \path\to\Java\Agent`.
+Additionally you can also set the InspectIT CMR host by passing in a second argument:
+`start_all_with_inspectIT.sh \path\to\Java\Agent localhost`. If no CMR host is provided `localhost` is used by default.  
+The services can be stopped by executing the following script:
 `stop_all.sh`
 ## Starting services locally with docker-compose
 In order to start entire infrastructure using Docker, you have to build images by executing `mvn clean install -PbuildDocker` 

--- a/start_all_with_inspectIT.bat
+++ b/start_all_with_inspectIT.bat
@@ -1,12 +1,12 @@
 @echo off
 
-rem usage: Start_all_with_inspectIT.bat <agent_path>
+rem usage: Start_all_with_inspectIT.bat <agent_path> <cmr_host>
 rem the startup scipt must be placed in the same folder than the spring petclinic application
 rem the path to the inspectit installation folder and the WAITTIME between the startup of the services
 rem !!!!do not use spaces in the path of inspectIT installation folder!!!!
 
 set AGENTDIR=%1
-set WAITTIME=10
+set WAITTIME=5
 set /a "x = 0"
 
 rem STARTTYPE, z.B. /B = start without open a new windows, /MIN start minized in new windows
@@ -14,9 +14,15 @@ set STARTTYPE=/B
 
 if not exist "%AGENTDIR%/inspectit-agent.jar" (
 	echo Agent jar not found. Specify the path to the inspectIT agent
-	echo Example: Start_all_with_inspectIT.bat c:/user/inspectIT/agent.
+	echo Example: Start_all_with_inspectIT.bat c:/user/inspectIT/agent localhost.
 	echo In case you have not installed inspectIT go to https://github.com/inspectIT/inspectIT/releases
 	goto :eof
+)
+
+if not "%~2"=="" (
+	set CMR_HOST=%2
+) else (
+	set CMR_HOST=localhost
 )
 
 call mvn clean install -DskipTests
@@ -24,82 +30,100 @@ echo "Agent jar found."
 cd spring-petclinic-config-server
 echo "Starting Configuration Server"
 if exist configuration-log.txt del configuration-log.txt
+ping 127.0.0.1 -n 1 > nul
 start %STARTTYPE% mvn spring-boot:run > configuration-log.txt
 cd ..
-echo "Waiting for Configuration Server"
+echo|set /p="Waiting for Configuration Server"
 :loop1
 set /a "x = x + 1"
 if %x% geq 60 (
-goto :eof
+	goto :eof
 )
+
+echo|set /p="."
 
 find  "Started ConfigServerApplication" spring-petclinic-config-server\configuration-log.txt > nul
 if errorlevel 1 (
-	timeout /T 1 > nul
+	ping 127.0.0.1 -n 2 > nul
 	goto :loop1
 )
 set /a "x = 0"
 
+echo .
+
 cd spring-petclinic-discovery-server
 echo "Starting Discovery Server"
 if exist discovery-log.txt del discovery-log.txt
+ping 127.0.0.1 -n 1 > nul
 start %STARTTYPE% mvn spring-boot:run > discovery-log.txt
 cd ..
-echo "Waiting for Eureka Service"
+echo|set /p="Waiting for Eureka Service"
 :loop2
 set /a "x = x + 1"
 
 if %x% geq 60 (
-goto :eof
+	goto :eof
 )
+
+echo|set /p="."
+
 find  "Started DiscoveryServerApplication" spring-petclinic-discovery-server\discovery-log.txt > nul
 if errorlevel 1 (
-	timeout /T 1 > nul
+	ping 127.0.0.1 -n 2 > nul
 	goto :loop2
 )
 start "" http://localhost:8761
 
+echo .
 
 set /a "x = 0"
 
 cd spring-petclinic-customers-service
 echo "Starting Customers Service"
-start %STARTTYPE% mvn spring-boot:run -Drun.jvmArguments="-javaagent:%AGENTDIR%/inspectit-agent.jar -Dinspectit.repository=localhost:9070 -Dinspectit.agent.name=customers-service"
+start %STARTTYPE% mvn spring-boot:run -Drun.jvmArguments="-javaagent:%AGENTDIR%/inspectit-agent.jar -Dinspectit.repository=%CMR_HOST%:9070 -Dinspectit.agent.name=customers-service"
 cd ..
-timeout /T %WAITTIME% > nul
+ping 127.0.0.1 -n %WAITTIME% > nul
 cd spring-petclinic-vets-service
 echo "Starting Vets Service"
-start %STARTTYPE% mvn spring-boot:run -Drun.jvmArguments="-javaagent:%AGENTDIR%/inspectit-agent.jar -Dinspectit.repository=localhost:9070 -Dinspectit.agent.name=vets-service"
+start %STARTTYPE% mvn spring-boot:run -Drun.jvmArguments="-javaagent:%AGENTDIR%/inspectit-agent.jar -Dinspectit.repository=%CMR_HOST%:9070 -Dinspectit.agent.name=vets-service"
 cd ..
-timeout /T %WAITTIME% > nul
+ping 127.0.0.1 -n %WAITTIME% > nul
 cd spring-petclinic-visits-service
 echo "Starting Visits Service"
-start %STARTTYPE% mvn spring-boot:run -Drun.jvmArguments="-javaagent:%AGENTDIR%/inspectit-agent.jar -Dinspectit.repository=localhost:9070 -Dinspectit.agent.name=visits-service"
+start %STARTTYPE% mvn spring-boot:run -Drun.jvmArguments="-javaagent:%AGENTDIR%/inspectit-agent.jar -Dinspectit.repository=%CMR_HOST%:9070 -Dinspectit.agent.name=visits-service"
 cd ..
-timeout /T %WAITTIME% > nul
+ping 127.0.0.1 -n %WAITTIME% > nul
 cd spring-petclinic-api-gateway
 echo "Starting API Gateway"
 if exist api-gateway-log.txt del api-gateway-log.txt
-start %STARTTYPE% mvn spring-boot:run -Drun.jvmArguments="-javaagent:%AGENTDIR%/inspectit-agent.jar -Dinspectit.repository=localhost:9070 -Dinspectit.agent.name=api-gateway" > api-gateway-log.txt
+ping 127.0.0.1 -n 1 > nul
+start %STARTTYPE% mvn spring-boot:run -Drun.jvmArguments="-javaagent:%AGENTDIR%/inspectit-agent.jar -Dinspectit.repository=%CMR_HOST%:9070 -Dinspectit.agent.name=api-gateway" > api-gateway-log.txt
 cd ..
-timeout /T %WAITTIME% > nul
+ping 127.0.0.1 -n %WAITTIME% > nul
 cd spring-petclinic-admin-server
 echo "Starting Admin Server"
-start %STARTTYPE% mvn spring-boot:run -Drun.jvmArguments="-javaagent:%AGENTDIR%/inspectit-agent.jar -Dinspectit.repository=localhost:9070 -Dinspectit.agent.name=admin-server"
+ping 127.0.0.1 -n %WAITTIME% > nul
+start %STARTTYPE% mvn spring-boot:run -Drun.jvmArguments="-javaagent:%AGENTDIR%/inspectit-agent.jar -Dinspectit.repository=%CMR_HOST%:9070 -Dinspectit.agent.name=admin-server"
 cd ..
-echo "Waiting for Api Gateway"
+echo|set /p="Waiting for Api Gateway"
 :loop3
 set /a "x = x + 1"
 
 if %x% geq 200 (
-goto :eof
+	goto :eof
 )
+
+echo|set /p="."
+
 find  "Started ApiGatewayApplication" spring-petclinic-api-gateway\api-gateway-log.txt > nul
 if errorlevel 1 (
-	timeout /T 1 > nul
+	ping 127.0.0.1 -n 2 > nul
 	goto :loop3
 )
 start "" http://localhost:8080
+
+echo .
+
 set /a "x = 0"
 
 echo "All Services started!"


### PR DESCRIPTION
Update bat start script to support Jenkins.

In the Jenkins environment the timeout command was not recognized and thus the script was unusable. The timeout command was replaced with the ping command to provide the same functionality and works now under Windows and in the Jenkins environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit-labs/spring-petclinic-microservices/9)
<!-- Reviewable:end -->
